### PR TITLE
Corrected comments to change usage examples

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
@@ -133,7 +133,7 @@ function entityResource($q, $http, umbRequestHelper) {
          * ##usage
          * <pre>
          * //get media by id
-         * entityResource.getEntityById(0, "Media")
+         * entityResource.getById(0, "Media")
          *    .then(function(ent) {
          *        var myDoc = ent;
          *        alert('its here!');
@@ -204,7 +204,7 @@ function entityResource($q, $http, umbRequestHelper) {
          * ##usage
          * <pre>
          * //Get templates for ids
-         * entityResource.getEntitiesByIds( [1234,2526,28262], "Template")
+         * entityResource.getByIds( [1234,2526,28262], "Template")
          *    .then(function(templateArray) {
          *        var myDoc = contentArray;
          *        alert('they are here!');


### PR DESCRIPTION
Corrected usage examples for entityResource.js

My first Umbraco commit! yay!

### Prerequisites

No prerequisites.  Should be a documentation fix only for https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.resources.entityResource

This fixes https://github.com/umbraco/Umbraco-CMS/issues/6068

### Description

Usage examples currently say entityResource.getEntityById(0, "Media")  But the method is just .getById( ....)
